### PR TITLE
fix extra window bug

### DIFF
--- a/MP3Player/AppDelegate.swift
+++ b/MP3Player/AppDelegate.swift
@@ -80,9 +80,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, AVAudioPlayerDelegate {
             }
             _ = application(NSApp, openFile: mp3File)
         } else {
-            // Launched normally - setup window and wait for file via "Open With"
-            setupWindow()
-            if fileWasOpened == false {
+            if !fileWasOpened {
+                setupWindow()
                 updateOverlay("Drop MP3 onto app icon or use 'Open With'...")
             }
             window.makeKeyAndOrderFront(nil)


### PR DESCRIPTION
Added a check in `applicationDidFinishLaunching` to only run setup window if `fileWasOpened` is false. This makes it so the window is only opened in `applicationDidFinishLaunching` if the user opens the application by clicking on the icon (not by opening via a "Open With..." or command line.