### PR TITLE
Replace overlay with a native practice jukebox window.

### DIFF
--- a/MP3Player/AppDelegate.swift
+++ b/MP3Player/AppDelegate.swift
@@ -1,212 +1,255 @@
 import Cocoa
 import AVFoundation
+import UniformTypeIdentifiers
 
 @NSApplicationMain
-class AppDelegate: NSObject, NSApplicationDelegate, AVAudioPlayerDelegate {
-    
+class AppDelegate: NSObject, NSApplicationDelegate, AVAudioPlayerDelegate, NSWindowDelegate {
+
     var window: PlayerWindow!
     var player: AVAudioPlayer?
     var fileWasOpened = false
     var mp3Files: [String] = []
     var currentIndex: Int = 0
-    var currentPos: TimeInterval = 0.0
     var isPaused = false
+    var finishedCurrentTrack = false
     var folder: String = ""
-    var autoAdvanceTimer: Timer?
-    var statusLabel: NSTextField!
-    
+    var progressTimer: Timer?
+
     func application(_ sender: NSApplication, openFile filename: String) -> Bool {
-        // This gets called when a file is opened with your app
         guard FileManager.default.fileExists(atPath: filename) else {
             print("File not found: \(filename)")
             return false
         }
-        
+
         folder = (filename as NSString).deletingLastPathComponent
         mp3Files = (try? FileManager.default.contentsOfDirectory(atPath: folder)
             .filter { $0.lowercased().hasSuffix(".mp3") }
             .sorted()) ?? []
-        
+
         guard let index = mp3Files.firstIndex(of: (filename as NSString).lastPathComponent) else {
             print("MP3 not in folder.")
             return false
         }
+
         currentIndex = index
         fileWasOpened = true
-        
-        // Setup window if not already done
-        if window == nil {
-            setupWindow()
-        }
-        
-        // Load and play the selected track
+
+        ensureWindow()
+
         playFile(at: currentIndex, start: 0.0)
-        
-        // Start auto-advance timer if not already running
-        if autoAdvanceTimer == nil {
-            autoAdvanceTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { _ in
-                guard let player = self.player else { return }
-                if !player.isPlaying && !self.isPaused && player.currentTime >= (player.duration - 0.1) {
-                    self.nextTrack()
-                }
-            }
-        }
-        
-        // Make window key and front
-        window.makeKeyAndOrderFront(nil)
-        NSApp.activate(ignoringOtherApps: true)
-        window.makeFirstResponder(statusLabel)
-        
+        startProgressTimer()
+        presentWindow()
         return true
     }
-    
+
     func applicationDidFinishLaunching(_ aNotification: Notification) {
-        // Hide any default windows that might have been created
-        for window in NSApp.windows {
-            if window !== self.window {
-                window.orderOut(nil)
-            }
+        for existing in NSApp.windows where existing !== window {
+            existing.orderOut(nil)
         }
-        
-        // Check if launched with command-line arguments
-        let args = CommandLine.arguments
-        if args.count > 1 {
-            // Launched from command line with file path
-            let mp3File = args[1]
-            guard FileManager.default.fileExists(atPath: mp3File) else {
+
+        bindOpenMenu()
+
+        // Xcode passes flags like -NSDocumentRevisionsDebugMode; only treat real paths as files.
+        if let mp3File = CommandLine.arguments.dropFirst().first(where: { arg in
+            !arg.hasPrefix("-") && arg.lowercased().hasSuffix(".mp3")
+        }) {
+            if FileManager.default.fileExists(atPath: mp3File) {
+                _ = application(NSApp, openFile: mp3File)
+            } else {
                 print("File not found: \(mp3File)")
-                NSApp.terminate(nil)
-                return
+                ensureWindow()
+                window.setIdleMessage("File not found")
+                presentWindow()
             }
-            _ = application(NSApp, openFile: mp3File)
-        } else {
-            if !fileWasOpened {
-                setupWindow()
-                updateOverlay("Drop MP3 onto app icon or use 'Open With'...")
-            }
-            window.makeKeyAndOrderFront(nil)
-            NSApp.activate(ignoringOtherApps: true)
-            window.makeFirstResponder(statusLabel)
+        } else if !fileWasOpened {
+            ensureWindow()
+            window.setIdleMessage("Open an MP3 to start")
+            presentWindow()
         }
     }
-    
-    func setupWindow() {
-        window = PlayerWindow()
-        window.styleMask = [.borderless, .fullSizeContentView]
-        window.isMovableByWindowBackground = true
-        window.level = .floating  // Always on top
-        window.hasShadow = false
-        window.backgroundColor = .black
-        window.isOpaque = true
-        
-        // Center at top
-        let screen = NSScreen.main ?? NSScreen.screens[0]
-        let screenWidth = screen.frame.width
-        window.setFrame(NSRect(x: (screenWidth - 450)/2, y: screen.frame.height - 60, width: 450, height: 30), display: true)
-        
-        // Status label
-        statusLabel = NSTextField(labelWithString: "")
-        statusLabel.font = NSFont.monospacedSystemFont(ofSize: 16, weight: .regular)
-        statusLabel.textColor = .white
-        statusLabel.alignment = .center
-        statusLabel.drawsBackground = false
-        statusLabel.isBordered = false
-        statusLabel.isEditable = false
-        statusLabel.isSelectable = false
-        statusLabel.focusRingType = .none
-        window.contentView = statusLabel
-        
-        // CHANGE THIS: Set first responder to statusLabel instead of window
-        window.makeFirstResponder(statusLabel)
-        
-        // MOVE AND ADD: Set window.delegate after content setup, and add playerDelegate
-        window.delegate = self  // For potential window events (NSWindowDelegate)
-        window.playerDelegate = self  // ADD THIS: Custom delegate for key handling
-        
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        false
     }
-    
-    func updateOverlay(_ text: String) {
-        DispatchQueue.main.async {
-            self.statusLabel.stringValue = text
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        ensureWindow()
+        presentWindow()
+        return true
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        sender.orderOut(nil)
+        return false
+    }
+
+    func applicationWillTerminate(_ aNotification: Notification) {
+        player?.stop()
+        progressTimer?.invalidate()
+    }
+
+    func ensureWindow() {
+        if window == nil {
+            window = PlayerWindow()
+            window.delegate = self
+            window.playerDelegate = self
+            window.center()
         }
     }
-    
+
+    func presentWindow() {
+        NSApp.activate(ignoringOtherApps: true)
+        window.makeKeyAndOrderFront(nil)
+        window.makeFirstResponder(window)
+    }
+
+    private func bindOpenMenu() {
+        guard let fileMenu = NSApp.mainMenu?.item(withTitle: "File")?.submenu,
+              let openItem = fileMenu.items.first(where: { $0.title.hasPrefix("Open") && !$0.title.contains("Recent") }) else {
+            return
+        }
+        openItem.target = self
+        openItem.action = #selector(openDocument(_:))
+        openItem.keyEquivalent = "o"
+    }
+
+    @objc func openDocument(_ sender: Any?) {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.mp3]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.message = "Choose an MP3 to play this folder"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        _ = application(NSApp, openFile: url.path)
+    }
+
     func playFile(at index: Int, start: TimeInterval) {
-        currentIndex = index % mp3Files.count
-        currentPos = start
+        guard !mp3Files.isEmpty else { return }
+        currentIndex = min(max(index, 0), mp3Files.count - 1)
+
         let filePath = (folder as NSString).appendingPathComponent(mp3Files[currentIndex])
-        guard let url = URL(string: "file://\(filePath.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")") else { return }
-        
+        let url = URL(fileURLWithPath: filePath)
+
         do {
             player = try AVAudioPlayer(contentsOf: url)
             player?.delegate = self
-            player?.currentTime = start
+            player?.prepareToPlay()
+            let duration = player?.duration ?? 0
+            player?.currentTime = min(max(0, start), max(0, duration - 0.01))
             player?.play()
             isPaused = false
-            updateOverlay("⏸ \(mp3Files[currentIndex])")
+            finishedCurrentTrack = false
+            window.setTrackName(displayName(for: mp3Files[currentIndex]))
+            window.setPlaying(true)
+            updateTimeDisplay()
         } catch {
             print("Error loading \(filePath): \(error)")
+            player?.stop()
+            player = nil
+            isPaused = true
+            finishedCurrentTrack = false
+            window.setIdleMessage("Couldn’t load \(mp3Files[currentIndex])")
         }
     }
-    
+
     func togglePause() {
-        guard let player = player else {
-            print("No player available—skipping toggle")
+        guard let player = player else { return }
+        if finishedCurrentTrack || player.currentTime >= player.duration - 0.05 {
+            restartTrack()
             return
         }
         if isPaused {
             player.play()
             isPaused = false
-            updateOverlay("⏸ \(mp3Files[currentIndex])")
+            window.setPlaying(true)
         } else {
             player.pause()
             isPaused = true
-            updateOverlay("▶ \(mp3Files[currentIndex])")
-            // Short delay to let pause settle before allowing auto-advance
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                // Optional: Force a state check here if needed
+            window.setPlaying(false)
+        }
+        updateTimeDisplay()
+    }
+
+    func restartTrack() {
+        guard player != nil else { return }
+        seek(to: 0)
+        player?.play()
+        isPaused = false
+        finishedCurrentTrack = false
+        window.setPlaying(true)
+        updateTimeDisplay()
+    }
+
+    func skipBack() {
+        guard let player = player else { return }
+        finishedCurrentTrack = false
+        seek(to: player.currentTime - 3)
+    }
+
+    func skipForward() {
+        guard let player = player else { return }
+        let target = player.currentTime + 3
+        if target >= player.duration {
+            player.currentTime = player.duration
+            player.pause()
+            isPaused = true
+            finishedCurrentTrack = true
+            window.setPlaying(false)
+            updateTimeDisplay()
+            return
+        }
+        seek(to: target)
+    }
+
+    func seek(to time: TimeInterval) {
+        guard let player = player else { return }
+        player.currentTime = min(max(0, time), max(0, player.duration))
+        updateTimeDisplay()
+    }
+
+    func finishSliderSeek(to time: TimeInterval) {
+        guard let player = player else { return }
+        let duration = player.duration
+        if duration > 0, time >= duration - 0.05, currentIndex < mp3Files.count - 1 {
+            nextTrack()
+            return
+        }
+        seek(to: time)
+    }
+
+    func prevTrack() {
+        playFile(at: max(0, currentIndex - 1), start: 0)
+    }
+
+    func nextTrack() {
+        playFile(at: min(currentIndex + 1, mp3Files.count - 1), start: 0)
+    }
+
+    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        if flag && !isPaused && currentIndex < mp3Files.count - 1 {
+            nextTrack()
+        } else if flag {
+            isPaused = true
+            finishedCurrentTrack = true
+            window.setPlaying(false)
+            updateTimeDisplay()
+        }
+    }
+
+    private func startProgressTimer() {
+        if progressTimer == nil {
+            progressTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] _ in
+                self?.updateTimeDisplay()
             }
         }
     }
-    
-    func restartTrack() {
-        playFile(at: currentIndex, start: 0.0)
-    }
-    
-    func skipBack() {
-        guard let player = player else { return }
-        currentPos = max(0, player.currentTime - 3)
-        playFile(at: currentIndex, start: currentPos)
-    }
-    
-    func skipForward() {
-        guard let player = player else { return }
-        currentPos = player.currentTime + 3
-        playFile(at: currentIndex, start: currentPos)
-    }
-    
-    func prevTrack() {
-        playFile(at: max(0, currentIndex - 1), start: 0.0)
-    }
-    
-    func nextTrack() {
-        playFile(at: min(currentIndex + 1, mp3Files.count - 1), start: 0.0)
-    }
-    
-    // AVAudioPlayerDelegate: Auto-advance on finish
-    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
-        if flag && !isPaused {  // Already has this, but confirm
-            nextTrack()
-        }
-    }
-    
-    func applicationWillTerminate(_ aNotification: Notification) {
-        player?.stop()
-        autoAdvanceTimer?.invalidate()
-    }
-}
 
-// MARK: - NSApplicationDelegate extension for window events (if needed)
-extension AppDelegate: NSWindowDelegate {
-    // Override if you need window close handling
+    private func updateTimeDisplay() {
+        guard let player = player else { return }
+        window.setTime(current: player.currentTime, duration: player.duration)
+    }
+
+    private func displayName(for filename: String) -> String {
+        (filename as NSString).deletingPathExtension
+    }
 }

--- a/MP3Player/Base.lproj/Main.storyboard
+++ b/MP3Player/Base.lproj/Main.storyboard
@@ -1,7 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="11134" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11134"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22505"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Application-->
@@ -673,45 +675,11 @@
                         <outlet property="delegate" destination="Voe-Tx-rLC" id="PrD-fu-P6m"/>
                     </connections>
                 </application>
-                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModuleProvider="target"/>
+                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="MP3Player" customModuleProvider="target"/>
                 <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
                 <customObject id="Ady-hI-5gd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="75" y="0.0"/>
-        </scene>
-        <!--Window Controller-->
-        <scene sceneID="R2V-B0-nI4">
-            <objects>
-                <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
-                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
-                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
-                        <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-                        <rect key="contentRect" x="196" y="240" width="480" height="270"/>
-                        <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
-                        <connections>
-                            <outlet property="delegate" destination="B8D-0N-5wS" id="98r-iN-zZc"/>
-                        </connections>
-                    </window>
-                    <connections>
-                        <segue destination="XfG-lQ-9wD" kind="relationship" relationship="window.shadowedContentViewController" id="cq2-FE-JQM"/>
-                    </connections>
-                </windowController>
-                <customObject id="Oky-zY-oP4" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="75" y="250"/>
-        </scene>
-        <!--View Controller-->
-        <scene sceneID="hIz-AP-VOD">
-            <objects>
-                <viewController id="XfG-lQ-9wD" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" id="m2S-Jp-Qdl">
-                        <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </view>
-                </viewController>
-                <customObject id="rPt-NT-nkU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="75" y="655"/>
         </scene>
     </scenes>
 </document>

--- a/MP3Player/PlayerWindow.swift
+++ b/MP3Player/PlayerWindow.swift
@@ -2,39 +2,214 @@ import Cocoa
 
 class PlayerWindow: NSWindow {
     weak var playerDelegate: AppDelegate?
-    
+
+    let titleLabel = NSTextField(labelWithString: "No Track")
+    let timeLabel = NSTextField(labelWithString: "0:00 / 0:00")
+    let progressSlider = NSSlider()
+    let playPauseButton = NSButton()
+    let prevButton = NSButton()
+    let nextButton = NSButton()
+    let backButton = NSButton()
+    let forwardButton = NSButton()
+
+    private var isSeeking = false
+
+    override init(contentRect: NSRect, styleMask style: NSWindow.StyleMask, backing backingStoreType: NSWindow.BackingStoreType, defer flag: Bool) {
+        super.init(contentRect: contentRect, styleMask: style, backing: backingStoreType, defer: flag)
+        setupChrome()
+        setupContent()
+    }
+
+    convenience init() {
+        let style: NSWindow.StyleMask = [.titled, .closable, .miniaturizable, .fullSizeContentView]
+        self.init(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 148),
+            styleMask: style,
+            backing: .buffered,
+            defer: false
+        )
+    }
+
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { true }
+
     override func keyDown(with event: NSEvent) {
         guard playerDelegate != nil else {
             super.keyDown(with: event)
             return
         }
-            
-        // let characters = event.charactersIgnoringModifiers ?? ""
-        let keyCode = event.keyCode
-        
-        switch keyCode {
-        case 49:  // Space
-            playerDelegate?.togglePause() 
-        case 82, 29, 36:  // KP_0 (keypad 0), 0, and return
+
+        switch event.keyCode {
+        case 49: // Space
+            playerDelegate?.togglePause()
+        case 15, 82, 36: // R, keypad 0, Return — keyboard 0 is reserved for 100% speed
             playerDelegate?.restartTrack()
-        case 123:  // Left arrow
+        case 123: // Left
             playerDelegate?.skipBack()
-        case 124:  // Right arrow
+        case 124: // Right
             playerDelegate?.skipForward()
-        case 43:   // , (comma)
+        case 43: // comma
             playerDelegate?.prevTrack()
-        case 47:   // . (period)
+        case 47: // period
             playerDelegate?.nextTrack()
         default:
             super.keyDown(with: event)
         }
     }
-    
-    override var canBecomeKey: Bool {
-        return true  // Allow borderless window to be key
+
+    func setPlaying(_ playing: Bool) {
+        playPauseButton.image = NSImage(
+            systemSymbolName: playing ? "pause.fill" : "play.fill",
+            accessibilityDescription: playing ? "Pause" : "Play"
+        )
     }
-    
-    override var canBecomeMain: Bool {
-        return true  // Allow it to be main window
+
+    func setTrackName(_ name: String) {
+        titleLabel.stringValue = name
+        self.title = name
+    }
+
+    func setTime(current: TimeInterval, duration: TimeInterval) {
+        timeLabel.stringValue = "\(formatTime(current)) / \(formatTime(duration))"
+        guard !isSeeking, duration > 0 else { return }
+        progressSlider.maxValue = duration
+        progressSlider.doubleValue = current
+    }
+
+    func setIdleMessage(_ message: String) {
+        titleLabel.stringValue = message
+        self.title = "MP3 Player"
+        timeLabel.stringValue = "0:00 / 0:00"
+        progressSlider.doubleValue = 0
+        progressSlider.maxValue = 1
+        setPlaying(false)
+    }
+
+    private func setupChrome() {
+        title = "MP3 Player"
+        titlebarAppearsTransparent = true
+        titleVisibility = .hidden
+        isMovableByWindowBackground = true
+        isReleasedWhenClosed = false
+        backgroundColor = .windowBackgroundColor
+    }
+
+    private func setupContent() {
+        let root = NSView(frame: NSRect(x: 0, y: 0, width: 360, height: 148))
+        root.wantsLayer = true
+        contentView = root
+
+        titleLabel.font = NSFont.systemFont(ofSize: 13, weight: .semibold)
+        titleLabel.alignment = .center
+        titleLabel.lineBreakMode = .byTruncatingMiddle
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        timeLabel.font = NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+        timeLabel.textColor = .secondaryLabelColor
+        timeLabel.alignment = .center
+        timeLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        progressSlider.minValue = 0
+        progressSlider.maxValue = 1
+        progressSlider.doubleValue = 0
+        progressSlider.target = self
+        progressSlider.action = #selector(sliderChanged(_:))
+        progressSlider.refusesFirstResponder = true
+        progressSlider.isContinuous = true
+        progressSlider.translatesAutoresizingMaskIntoConstraints = false
+        _ = progressSlider.sendAction(on: [.leftMouseDown, .leftMouseDragged, .leftMouseUp])
+
+        configureButton(prevButton, symbol: "backward.end.fill", action: #selector(prevTapped), tooltip: "Previous track")
+        configureButton(backButton, symbol: "gobackward", action: #selector(backTapped), tooltip: "Skip back 3 seconds")
+        configureButton(playPauseButton, symbol: "play.fill", action: #selector(playPauseTapped), tooltip: "Play/Pause")
+        configureButton(forwardButton, symbol: "goforward", action: #selector(forwardTapped), tooltip: "Skip forward 3 seconds")
+        configureButton(nextButton, symbol: "forward.end.fill", action: #selector(nextTapped), tooltip: "Next track")
+
+        let controls = NSStackView(views: [prevButton, backButton, playPauseButton, forwardButton, nextButton])
+        controls.orientation = .horizontal
+        controls.alignment = .centerY
+        controls.spacing = 12
+        controls.translatesAutoresizingMaskIntoConstraints = false
+
+        root.addSubview(titleLabel)
+        root.addSubview(progressSlider)
+        root.addSubview(timeLabel)
+        root.addSubview(controls)
+
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: root.topAnchor, constant: 36),
+            titleLabel.leadingAnchor.constraint(equalTo: root.leadingAnchor, constant: 16),
+            titleLabel.trailingAnchor.constraint(equalTo: root.trailingAnchor, constant: -16),
+
+            progressSlider.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 10),
+            progressSlider.leadingAnchor.constraint(equalTo: root.leadingAnchor, constant: 16),
+            progressSlider.trailingAnchor.constraint(equalTo: root.trailingAnchor, constant: -16),
+
+            timeLabel.topAnchor.constraint(equalTo: progressSlider.bottomAnchor, constant: 2),
+            timeLabel.centerXAnchor.constraint(equalTo: root.centerXAnchor),
+
+            controls.topAnchor.constraint(equalTo: timeLabel.bottomAnchor, constant: 8),
+            controls.centerXAnchor.constraint(equalTo: root.centerXAnchor),
+            controls.bottomAnchor.constraint(lessThanOrEqualTo: root.bottomAnchor, constant: -12)
+        ])
+    }
+
+    private func configureButton(_ button: NSButton, symbol: String, action: Selector, tooltip: String) {
+        button.bezelStyle = .regularSquare
+        button.isBordered = false
+        button.image = NSImage(systemSymbolName: symbol, accessibilityDescription: tooltip)
+        button.imagePosition = .imageOnly
+        button.toolTip = tooltip
+        button.target = self
+        button.action = action
+        button.refusesFirstResponder = true
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.widthAnchor.constraint(equalToConstant: 28).isActive = true
+        button.heightAnchor.constraint(equalToConstant: 28).isActive = true
+    }
+
+    @objc private func playPauseTapped() {
+        playerDelegate?.togglePause()
+        makeFirstResponder(self)
+    }
+
+    @objc private func prevTapped() {
+        playerDelegate?.prevTrack()
+        makeFirstResponder(self)
+    }
+
+    @objc private func nextTapped() {
+        playerDelegate?.nextTrack()
+        makeFirstResponder(self)
+    }
+
+    @objc private func backTapped() {
+        playerDelegate?.skipBack()
+        makeFirstResponder(self)
+    }
+
+    @objc private func forwardTapped() {
+        playerDelegate?.skipForward()
+        makeFirstResponder(self)
+    }
+
+    @objc private func sliderChanged(_ sender: NSSlider) {
+        isSeeking = true
+        let eventType = NSApp.currentEvent?.type
+        if eventType == .leftMouseUp {
+            playerDelegate?.finishSliderSeek(to: sender.doubleValue)
+            isSeeking = false
+            makeFirstResponder(self)
+        } else {
+            playerDelegate?.seek(to: sender.doubleValue)
+        }
+    }
+
+    private func formatTime(_ time: TimeInterval) -> String {
+        guard time.isFinite, time >= 0 else { return "0:00" }
+        let total = Int(time.rounded(.down))
+        let minutes = total / 60
+        let seconds = total % 60
+        return String(format: "%d:%02d", minutes, seconds)
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,72 +1,55 @@
-# MP3 Player - macOS Overlay Player
+# MP3 Player
 
-A minimalist macOS MP3 player that displays a floating overlay window at the top of your screen. Control playback with keyboard shortcuts and navigate through entire folders of MP3 files.
+A small native macOS folder jukebox for practice. Open one MP3 and play the rest of that folder in name order, mostly from the keyboard.
 
 ## Features
 
-- **Floating overlay window** - Always visible at the top of your screen
-- **Keyboard controls** - No need to click, just use keys
-- **Folder playback** - Automatically plays all MP3s in the same folder
-- **"Open With" support** - Right-click any MP3 in Finder to open with this player
-- **Auto-advance** - Automatically moves to the next track when one finishes
+- **Compact macOS window** — title, progress, and transport buttons
+- **Keyboard-first** — play, scrub, restart, and skip tracks without the mouse
+- **Folder playback** — other MP3s in the same folder, name order
+- **Open With** — right-click an MP3 in Finder → Open With → MP3Player
+- **Auto-advance** — next track when one finishes
+- **Hide on close** — red button hides the window; playback keeps going; Dock icon stays. ⌘Q quits.
 
 ## Limitations
-- **Only supports MP3 files at this time**
+
+- MP3 files only
+- Playback speed is not implemented yet (`1`–`9` and keyboard `0` are reserved)
 
 ## Keyboard Controls
 
-- **Space** - Play/Pause
-- **R** - Restart current track
-- **Left Arrow** - Skip back 3 seconds
-- **Right Arrow** - Skip forward 3 seconds
-- **Comma (,)** - Previous track
-- **Period (.)** - Next track
-- **CMD+Q** - Quit
+- **Space** — Play/Pause
+- **R**, **Return**, or **numpad 0** — Restart current track
+- **Keyboard 0** — reserved (will be 100% speed)
+- **1–9** — reserved (will be 10%–90% speed)
+- **Left / Right Arrow** — Skip back / forward 3 seconds
+- **Comma (,)** — Previous track
+- **Period (.)** — Next track
+- **⌘O** — Open…
+- **⌘Q** — Quit
+
+## Launch
+
+- Double-click the app or Run from Xcode → idle window: “Open an MP3 to start”
+- Finder: right-click an `.mp3` → **Open With** → MP3Player
+- Drag an MP3 onto the Dock icon
+- File → Open…
+- Command line: `./MP3Player /path/to/your/song.mp3`
+
+If the app doesn’t appear in Open With:
+
+1. Right-click any MP3 → **Get Info**
+2. **Open with:** → choose this app
+3. **Change All…** if you want it as the default
 
 ## Building from Source
 
-### 1. Clone or Download the Project
-```bash
-git clone https://github.com/theehehron/audio-player.git
-```
-
-### 2. Open in Xcode
-- Open `MP3Player.xcodeproj` in Xcode
-
-### 3. Build the App
-- **Press ⌘+B** to build
-- **Or Product → Build**
-
-### 4. Export for Distribution
-**Quick Test Build**
-1. **Product → Show Build Folder in Finder**
-2. **Navigatate to .app file and Copy the .app file** to your Applications folder
-
-### GUI Usage
-1. **Copy the app** to your Applications folder
-2. **Right-click any MP3** in Finder
-3. **Open With** → Select MP3Player
-4. **Or drag MP3 files** onto the app icon
-
-### Command Line Usage
-```bash
-./MP3Player /path/to/your/song.mp3
-```
-
-### Register as MP3 Handler
-If the app doesn't appear in "Open With" menus:
-1. **Right-click any MP3** → **Get Info**
-2. **Open with:** → **Choose your app**
-3. **Click "Change All..."** to set as default
+1. Open `MP3Player.xcodeproj` in Xcode
+2. Scheme **MP3Player**, destination **My Mac**
+3. Product → Run (⌘R), or Product → Build and open the `.app` in the build folder
 
 ## Key Files
 
-- **AppDelegate.swift** - Contains all the music playback logic, file handling, and UI management
-- **PlayerWindow.swift** - Custom NSWindow subclass that handles keyboard input
-- **Info.plist** - Configures the app to handle MP3 files
-
-## Customization
-
-- **Change keyboard shortcuts** - Edit the key codes in PlayerWindow.swift
-- **Modify overlay appearance** - Edit setupWindow() in AppDelegate.swift  
-- **Add More Features** - Do whatever you want lol
+- **AppDelegate.swift** — Playback, folder scan, launch, File → Open
+- **PlayerWindow.swift** — Player window, controls, and keyboard input
+- **Info.plist** — Registers the app as an MP3 handler


### PR DESCRIPTION
AI Disclaimer: AI was used in the writing of this pull request 🤖

Compact titled player, folder playback, hide-on-close while audio continues, and keyboard-first transport. Fixes launch args from Xcode, seeking, and leftover storyboard window.