### PR TITLE
Add float-on-top and playback speed with heard-time skip.

### DIFF
--- a/MP3Player/AppDelegate.swift
+++ b/MP3Player/AppDelegate.swift
@@ -14,6 +14,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, AVAudioPlayerDelegate, NSWin
     var finishedCurrentTrack = false
     var folder: String = ""
     var progressTimer: Timer?
+    var playbackRate: Float = 1.0
+    var floatsOnTop = true
+    var floatMenuItem: NSMenuItem?
 
     func application(_ sender: NSApplication, openFile filename: String) -> Bool {
         guard FileManager.default.fileExists(atPath: filename) else {
@@ -48,6 +51,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, AVAudioPlayerDelegate, NSWin
         }
 
         bindOpenMenu()
+        bindFloatMenu()
 
         // Xcode passes flags like -NSDocumentRevisionsDebugMode; only treat real paths as files.
         if let mp3File = CommandLine.arguments.dropFirst().first(where: { arg in
@@ -95,6 +99,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, AVAudioPlayerDelegate, NSWin
             window.playerDelegate = self
             window.center()
         }
+        window.setFloatsOnTop(floatsOnTop)
+        window.setSpeedPercent(Int((playbackRate * 100).rounded()))
     }
 
     func presentWindow() {
@@ -111,6 +117,27 @@ class AppDelegate: NSObject, NSApplicationDelegate, AVAudioPlayerDelegate, NSWin
         openItem.target = self
         openItem.action = #selector(openDocument(_:))
         openItem.keyEquivalent = "o"
+    }
+
+    private func bindFloatMenu() {
+        guard let windowMenu = NSApp.mainMenu?.item(withTitle: "Window")?.submenu else { return }
+        let item = NSMenuItem(
+            title: "Float on Top",
+            action: #selector(toggleFloatOnTop(_:)),
+            keyEquivalent: ""
+        )
+        item.target = self
+        item.state = floatsOnTop ? .on : .off
+        windowMenu.insertItem(item, at: 0)
+        windowMenu.insertItem(.separator(), at: 1)
+        floatMenuItem = item
+    }
+
+    @objc func toggleFloatOnTop(_ sender: Any?) {
+        floatsOnTop.toggle()
+        floatMenuItem?.state = floatsOnTop ? .on : .off
+        ensureWindow()
+        window.setFloatsOnTop(floatsOnTop)
     }
 
     @objc func openDocument(_ sender: Any?) {
@@ -133,14 +160,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, AVAudioPlayerDelegate, NSWin
         do {
             player = try AVAudioPlayer(contentsOf: url)
             player?.delegate = self
+            player?.enableRate = true
+            player?.rate = playbackRate
             player?.prepareToPlay()
             let duration = player?.duration ?? 0
             player?.currentTime = min(max(0, start), max(0, duration - 0.01))
             player?.play()
+            player?.rate = playbackRate
             isPaused = false
             finishedCurrentTrack = false
             window.setTrackName(displayName(for: mp3Files[currentIndex]))
             window.setPlaying(true)
+            window.setSpeedPercent(Int((playbackRate * 100).rounded()))
             updateTimeDisplay()
         } catch {
             print("Error loading \(filePath): \(error)")
@@ -183,12 +214,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, AVAudioPlayerDelegate, NSWin
     func skipBack() {
         guard let player = player else { return }
         finishedCurrentTrack = false
-        seek(to: player.currentTime - 3)
+        seek(to: player.currentTime - heardSkipDelta())
     }
 
     func skipForward() {
         guard let player = player else { return }
-        let target = player.currentTime + 3
+        let target = player.currentTime + heardSkipDelta()
         if target >= player.duration {
             player.currentTime = player.duration
             player.pause()
@@ -199,6 +230,20 @@ class AppDelegate: NSObject, NSApplicationDelegate, AVAudioPlayerDelegate, NSWin
             return
         }
         seek(to: target)
+    }
+
+    func setPlaybackPercent(_ percent: Int) {
+        let clamped = min(max(percent, 10), 100)
+        playbackRate = Float(clamped) / 100
+        if let player = player {
+            player.enableRate = true
+            player.rate = playbackRate
+        }
+        window.setSpeedPercent(clamped)
+    }
+
+    private func heardSkipDelta() -> TimeInterval {
+        3.0 * Double(playbackRate)
     }
 
     func seek(to time: TimeInterval) {

--- a/MP3Player/PlayerWindow.swift
+++ b/MP3Player/PlayerWindow.swift
@@ -5,6 +5,7 @@ class PlayerWindow: NSWindow {
 
     let titleLabel = NSTextField(labelWithString: "No Track")
     let timeLabel = NSTextField(labelWithString: "0:00 / 0:00")
+    let speedLabel = NSTextField(labelWithString: "100%")
     let progressSlider = NSSlider()
     let playPauseButton = NSButton()
     let prevButton = NSButton()
@@ -34,27 +35,81 @@ class PlayerWindow: NSWindow {
     override var canBecomeMain: Bool { true }
 
     override func keyDown(with event: NSEvent) {
-        guard playerDelegate != nil else {
-            super.keyDown(with: event)
+        if handleKeyEvent(event) { return }
+        super.keyDown(with: event)
+    }
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if isNumpadZero(event) {
+            playerDelegate?.restartTrack()
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
+    }
+
+    override func insertText(_ insertString: Any) {
+        let text = (insertString as? String) ?? (insertString as? NSString as String?) ?? ""
+        // Keypad 0 often arrives as insertText instead of a command keyDown.
+        // Top-row 0 is keyCode 29 and is handled in keyDown as 100% speed.
+        if text == "0", let event = NSApp.currentEvent, event.keyCode != 29 {
+            playerDelegate?.restartTrack()
             return
+        }
+        super.insertText(insertString)
+    }
+
+    /// Returns true if the event was a player command (so the caller should swallow it).
+    func handleKeyEvent(_ event: NSEvent) -> Bool {
+        guard playerDelegate != nil else { return false }
+
+        if isNumpadZero(event) {
+            playerDelegate?.restartTrack()
+            return true
         }
 
         switch event.keyCode {
         case 49: // Space
             playerDelegate?.togglePause()
-        case 15, 82, 36: // R, keypad 0, Return — keyboard 0 is reserved for 100% speed
+        case 15, 36: // R, Return
             playerDelegate?.restartTrack()
-        case 123: // Left
+        case 29: // keyboard 0
+            playerDelegate?.setPlaybackPercent(100)
+        case 18:
+            playerDelegate?.setPlaybackPercent(10)
+        case 19:
+            playerDelegate?.setPlaybackPercent(20)
+        case 20:
+            playerDelegate?.setPlaybackPercent(30)
+        case 21:
+            playerDelegate?.setPlaybackPercent(40)
+        case 23:
+            playerDelegate?.setPlaybackPercent(50)
+        case 22:
+            playerDelegate?.setPlaybackPercent(60)
+        case 26:
+            playerDelegate?.setPlaybackPercent(70)
+        case 28:
+            playerDelegate?.setPlaybackPercent(80)
+        case 25:
+            playerDelegate?.setPlaybackPercent(90)
+        case 123:
             playerDelegate?.skipBack()
-        case 124: // Right
+        case 124:
             playerDelegate?.skipForward()
-        case 43: // comma
+        case 43:
             playerDelegate?.prevTrack()
-        case 47: // period
+        case 47:
             playerDelegate?.nextTrack()
         default:
-            super.keyDown(with: event)
+            return false
         }
+        return true
+    }
+
+    private func isNumpadZero(_ event: NSEvent) -> Bool {
+        if event.keyCode == 82 { return true }
+        let chars = event.charactersIgnoringModifiers ?? ""
+        return event.modifierFlags.contains(.numericPad) && chars == "0"
     }
 
     func setPlaying(_ playing: Bool) {
@@ -85,6 +140,14 @@ class PlayerWindow: NSWindow {
         setPlaying(false)
     }
 
+    func setSpeedPercent(_ percent: Int) {
+        speedLabel.stringValue = "\(percent)%"
+    }
+
+    func setFloatsOnTop(_ floats: Bool) {
+        level = floats ? .floating : .normal
+    }
+
     private func setupChrome() {
         title = "MP3 Player"
         titlebarAppearsTransparent = true
@@ -92,6 +155,7 @@ class PlayerWindow: NSWindow {
         isMovableByWindowBackground = true
         isReleasedWhenClosed = false
         backgroundColor = .windowBackgroundColor
+        level = .floating
     }
 
     private func setupContent() {
@@ -108,6 +172,11 @@ class PlayerWindow: NSWindow {
         timeLabel.textColor = .secondaryLabelColor
         timeLabel.alignment = .center
         timeLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        speedLabel.font = NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+        speedLabel.textColor = .secondaryLabelColor
+        speedLabel.alignment = .right
+        speedLabel.translatesAutoresizingMaskIntoConstraints = false
 
         progressSlider.minValue = 0
         progressSlider.maxValue = 1
@@ -134,6 +203,7 @@ class PlayerWindow: NSWindow {
         root.addSubview(titleLabel)
         root.addSubview(progressSlider)
         root.addSubview(timeLabel)
+        root.addSubview(speedLabel)
         root.addSubview(controls)
 
         NSLayoutConstraint.activate([
@@ -147,6 +217,10 @@ class PlayerWindow: NSWindow {
 
             timeLabel.topAnchor.constraint(equalTo: progressSlider.bottomAnchor, constant: 2),
             timeLabel.centerXAnchor.constraint(equalTo: root.centerXAnchor),
+
+            speedLabel.centerYAnchor.constraint(equalTo: timeLabel.centerYAnchor),
+            speedLabel.trailingAnchor.constraint(equalTo: root.trailingAnchor, constant: -16),
+            speedLabel.leadingAnchor.constraint(greaterThanOrEqualTo: timeLabel.trailingAnchor, constant: 8),
 
             controls.topAnchor.constraint(equalTo: timeLabel.bottomAnchor, constant: 8),
             controls.centerXAnchor.constraint(equalTo: root.centerXAnchor),

--- a/README.md
+++ b/README.md
@@ -10,19 +10,20 @@ A small native macOS folder jukebox for practice. Open one MP3 and play the rest
 - **Open With** — right-click an MP3 in Finder → Open With → MP3Player
 - **Auto-advance** — next track when one finishes
 - **Hide on close** — red button hides the window; playback keeps going; Dock icon stays. ⌘Q quits.
+- **Float on Top** — window stays above other apps (on by default). Toggle via **Window → Float on Top**.
+- **Playback speed** — keyboard `1`–`9` set 10%–90%; keyboard `0` is 100%. Shown as a percent on the window. Resets to 100% each launch.
 
 ## Limitations
 
 - MP3 files only
-- Playback speed is not implemented yet (`1`–`9` and keyboard `0` are reserved)
 
 ## Keyboard Controls
 
 - **Space** — Play/Pause
 - **R**, **Return**, or **numpad 0** — Restart current track
-- **Keyboard 0** — reserved (will be 100% speed)
-- **1–9** — reserved (will be 10%–90% speed)
-- **Left / Right Arrow** — Skip back / forward 3 seconds
+- **Keyboard 0** — 100% speed
+- **1–9** — 10%–90% speed
+- **Left / Right Arrow** — Skip back / forward 3 seconds of **heard** time (scales with speed)
 - **Comma (,)** — Previous track
 - **Period (.)** — Next track
 - **⌘O** — Open…


### PR DESCRIPTION
Window stays above other apps by default (Window → Float on Top). Number keys set 10–100% speed; skip moves 3 seconds of heard time. Numpad 0 restarts instead of inserting text.